### PR TITLE
fix: slaves to workers, and typo

### DIFF
--- a/source/Reference/Using-RELION.rst
+++ b/source/Reference/Using-RELION.rst
@@ -106,11 +106,11 @@ With the much improved speed of image processing provided by the GPU-acceleratio
 Several options are available on the |RELION| GUI to optimise disk access for your data set and computer setup.
 For :jobtype:`2D classification`, :jobtype:`3D initial model`, :jobtype:`3D classification` and :jobtype:`3D auto-refine` one can choose to `use parallel  disc I/O`.
 When set to `Yes`, all MPI processes will read particles simultaneously from the hard disk.
-Otherwise, only the master will read images and send them through the network to the slaves.
+Otherwise, only the master will read images and send them through the network to the workers.
 Parallel file systems like gluster of fhgfs are good at parallel disc I/O.
-NFS may break with many slaves reading in parallel.
+NFS may break with many workers reading in parallel.
 
-One can also set the `number of pooled particles`.  Particles are processed in individual batches by MPI slaves.
+One can also set the `number of pooled particles`.  Particles are processed in individual batches by MPI workers.
 During each batch, a stack of particle images is only opened and closed once to improve disk access times.
 All particle images of a single batch are read into memory together.
 The size of these batches is at least one particle per thread used.
@@ -124,9 +124,9 @@ This will greatly speed up calculations on systems with relatively slow disk acc
 Because particles are read in float-precision, it will take :math:`\frac{N \times boxsize \times boxsize \times 4}{1024 \times 1024 \times 1024}` gigabytes to read N particles into RAM.
 For 100,000 particles with a 200-pixel boxsize that becomes 15GB, or 60 GB for the same number of particles in a 400-pixel boxsize.
 
-If the data set is too large to pre-read into RAM, but each computing node has a local, fast disk (e.g. a solid-state drive) mounted with the same name, then one can let each MPI slave copy all particles onto the local disk prior to starting the calculations.
+If the data set is too large to pre-read into RAM, but each computing node has a local, fast disk (e.g. a solid-state drive) mounted with the same name, then one can let each MPI worker copy all particles onto the local disk prior to starting the calculations.
 This is done using the ``Copy particles to scratch directory``.
-If multiple slaves will be executed on the same node, only the first slave will copy the particles.
+If multiple workers will be executed on the same node, only the first worker will copy the particles.
 If the local disk is too small to hold the entire data set, those particles that no loner fit on the scratch disk will be read from their original position.
 A sub-directory called ``relion_volatile`` will be created inside the specified directory name.
 For example, if one specifies ``/ssd``, then a directory called ``/ssd/relion_volatile`` will be created.
@@ -139,9 +139,9 @@ Thereby, one can choose to use ``/ssd``, i.e. without a username, as a scratch d
 That way, provided always only a single job is executed by a single user on each computing node, the local disks do not run the risk of filling up with junk when jobs crash and users forget to clean the scratch disk themselves.
 
 Finally, there is an option to ``combine iterations through disc``.
-If set to ``Yes``, at the end of every iteration all MPI slaves will write out a large file with their accumulated results.
+If set to ``Yes``, at the end of every iteration all MPI workers will write out a large file with their accumulated results.
 The MPI master will read in all these files, combine them all, and write out a new file with the combined results.
-All MPI salves will then read in the combined results.
+All MPI workers will then read in the combined results.
 This reduces heavy load on the network, but increases load on the disc I/O.
 This will affect the time it takes between the progress-bar in the expectation step reaching its end (the mouse gets to the cheese) and the start of the ensuing maximisation step.
 It will depend on your system setup which is most efficient.

--- a/source/SPA_tutorial/Autopicking.rst
+++ b/source/SPA_tutorial/Autopicking.rst
@@ -245,15 +245,15 @@ Ignore the :guitab:`Helix` tab, and on the :guitab:`Compute` tab, set:
 
 :Use parallel disc I/O?: Yes
 
-     (This way, all MPI slaves will read their own particles from disc.
+     (This way, all MPI workers will read their own particles from disc.
      Use this option if you have a fast (parallel?) file system.
      Note that non-parallel file systems may not be able to handle parallel access from multiple MPI nodes.
      In such cases one could set this option to No.
-     In that case, only the master MPI node will read in the particles and send them through the network to the MPI slaves.)
+     In that case, only the master MPI node will read in the particles and send them through the network to the MPI workers.)
 
 :Number of pooled particles:: 30
 
-     (Particles are processed in individual batches by MPI slaves.
+     (Particles are processed in individual batches by MPI workers.
      During each batch, a stack of particle images is only opened and closed once to improve disk access times.
      All particle images of a single batch are read into memory together.
      The size of these batches is at least one particle per thread used.
@@ -268,8 +268,8 @@ Ignore the :guitab:`Helix` tab, and on the :guitab:`Compute` tab, set:
      (If set to Yes, all particle images will be read into computer memory, which will greatly speed up calculations on systems with slow disk access.
      *However, one should of course be careful with the amount of RAM available.*
      Because particles are read in double-precision, it will take ( N × box_size × box_size × 4 / (1024 × 1024 × 1024) ) Giga-bytes to read N particles into RAM.
-     If parallel disc I/O is set to Yes, then all MPI slaves will read in all particles.
-     If parallel disc I/O is set to No, then only the master reads all particles into RAM and sends those particles through the network to the MPI slaves during the refinement iterations.)
+     If parallel disc I/O is set to Yes, then all MPI workers will read in all particles.
+     If parallel disc I/O is set to No, then only the master reads all particles into RAM and sends those particles through the network to the MPI workers during the refinement iterations.)
 
 :Copy particles to scratch directory?: \
 

--- a/source/SPA_tutorial/Refine3D.rst
+++ b/source/SPA_tutorial/Refine3D.rst
@@ -137,7 +137,7 @@ On the :guitab:`Compute` tab, we also replicate the settings of the :jobtype:`3D
 :Which GPUs to use: 0:1:2:3
 
   
-As the MPI nodes are divided between one master (who does nothing else than bossing the others around) and two sets of slaves who do all the work on the two half-sets, it is most efficient to use an odd number of MPI processors, and the minimum number of MPI processes for :jobtype:`3D auto-refine` jobs is 3.
+As the MPI nodes are divided between one master (who does nothing else than bossing the others around) and two sets of workers who do all the work on the two half-sets, it is most efficient to use an odd number of MPI processors, and the minimum number of MPI processes for :jobtype:`3D auto-refine` jobs is 3.
 Memory requirements may increase significantly at the final iteration, as all frequencies until Nyquist will be taken into account, so for larger sized boxes than the ones in this test data set you may want to run with as many threads as you have cores on your cluster nodes.
 
 On our computer with 4 GPUs, we used 5 MPIs and 6 threads, and this calculation took approximately 7 minutes.


### PR DESCRIPTION
Renamed all instances of MPI slaves to MPI workers. Resolves Issue #16 .